### PR TITLE
Make FlashUser and FlashState objects (py27)

### DIFF
--- a/iota/flash/api.py
+++ b/iota/flash/api.py
@@ -3,7 +3,7 @@ from typing import Iterable
 from iota.commands import discover_commands
 from iota.crypto.types import Digest
 from iota.flash.commands.create_transaction import CreateFlashTransactionCommand
-from iota.flash.commands.multisig.compose_address import ComposeAddressNodeCommand
+from iota.flash.commands.multisig.compose_address_node import ComposeAddressNodeCommand
 from iota.flash.types import FlashUser
 from iota.multisig import MultisigIota
 
@@ -56,7 +56,7 @@ class FlashIota(MultisigIota):
     """
 
     :param user: Flash object of user storing relevant metadata of the channel
-    :param transactions: list of transaction, wnich should be executed
+    :param transactions: list of transaction, which should be executed
     :param close: Flag indicating a closing of the channel
     :return:
       Dict with the following items::

--- a/iota/flash/types.py
+++ b/iota/flash/types.py
@@ -8,7 +8,7 @@ from iota import Bundle
 from iota.crypto.types import Seed, Digest
 
 
-class FlashUser:
+class FlashUser(object):
   """
   Object representing a user withing a Flash channel
   """
@@ -25,7 +25,7 @@ class FlashUser:
     self.partial_digests = []  # type: List[Digest]
 
 
-class FlashState:
+class FlashState(object):
   """
   Object storing information of the current state of the channel
   """


### PR DESCRIPTION
`filters.Required` calls `len(...)` and expects a `TypeError`.
If a class doesn't inherit from `object` in Python2.7 it throws an `AttributeError` when `len(...)` is called on it.

Edit: It wasn't running on py27